### PR TITLE
Disable w3c for chrome75+

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,8 @@ jobs:
       - checkout
       - run: bundle --version
       - run: gem --version
+      - run: google-chrome --version
+      - run: chromedriver --version
       - ruby-orbs/bundle-install:
           with_gemfile_lock: false
           gemspec_name: "apple_system_status"

--- a/lib/apple_system_status/crawler.rb
+++ b/lib/apple_system_status/crawler.rb
@@ -24,6 +24,7 @@ module AppleSystemStatus
 
         chrome_options = { args: chrome_options_args }
         chrome_options[:binary] = chrome_options_binary if chrome_options_binary
+        chrome_options[:w3c] = false # for chrome 75+
 
         capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(chromeOptions: chrome_options)
 


### PR DESCRIPTION
Can't fetch ajax response since chrome75+
https://circleci.com/workflow-run/ede25b11-e12e-4caa-a8ec-003798bc5818

So I disabled w3c option
c.f. https://bugs.chromium.org/p/chromium/issues/detail?id=971227#c7