### PR TITLE
Don't use selenium-webdriver v4

### DIFF
--- a/apple_system_status.gemspec
+++ b/apple_system_status.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "capybara"
-  spec.add_dependency "selenium-webdriver"
+  spec.add_dependency "selenium-webdriver", "< 4.0.0"
   spec.add_dependency "thor"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
Now, apple_system_status doesn't work with selenium-webdriver v4 :cry:

Close #62