### PR TITLE
Drop support ruby < 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,33 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in apple_system_status.gemspec
 gemspec
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.2.2")
-  # NOTE: rack 2.x supports only ruby 2.2.2+
-  gem "rack", "< 2.0.0"
-elsif Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.3.0")
-  # NOTE: rack 2.2 supports only ruby 2.3.0+
-  gem "rack", "< 2.2.0"
-end
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.3.0")
-  # NOTE: xpath 3.2.0+ requires ruby 2.3.0+
-  gem "xpath", "< 3.2.0"
-
-  # NOTE: selenium-webdriver 3.142.1+ requires ruby 2.3.0+
-  gem "selenium-webdriver", "< 3.142.1"
-
-  # NOTE: public_suffix v3.1.0+ requires ruby 2.3.0+
-  gem "public_suffix", "< 3.1.0"
-
-  # N0TE: unparser v0.5.0+ requires ruby 2.3.0+
-  gem "unparser", "< 0.5.0"
-end
-
-if Gem::Version.create(RUBY_VERSION) < Gem::Version.create("2.4.0")
-  # NOTE: capybara 3.16.0+ requires ruby 2.4.0+
-  gem "capybara", "< 3.16.0"
-
-  # NOTE: rubyzip 2.0.0+ requires ruby 2.4.0+
-  gem "rubyzip", "< 2.0.0"
-end

--- a/apple_system_status.gemspec
+++ b/apple_system_status.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sue445/apple_system_status"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.2"
+  spec.required_ruby_version = ">= 2.5"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.


### PR DESCRIPTION
* Ruby 2.4 is already EOL
  * https://www.ruby-lang.org/en/downloads/branches/
* Dropped build matrix for 2.2 to 2.4 at #64