### PR TITLE
Fix yard generationg error

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,8 @@ jobs:
       - run: bundle config --local path vendor/bundle
       - run: bundle install --jobs=4 --retry=3
       - run: bundle exec rspec
+      - run: bundle exec yard
+      - run: ls -ld doc/
       - slack/notify-on-failure
 
 build_jobs: &build_jobs

--- a/apple_system_status.gemspec
+++ b/apple_system_status.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-parameterized"
   spec.add_development_dependency "simplecov", "< 0.18.0"


### PR DESCRIPTION
```
/home/runner/work/apple_system_status/apple_system_status/vendor/bundle/ruby/4.0.0/gems/yard-0.9.38/lib/yard/templates/helpers/markup_helper.rb:105: warning: rdoc used to be loaded from the standard library, but is not part of the default gems since Ruby 4.0.0.
You can add rdoc to your Gemfile or gemspec to fix this error.
Error: : Missing 'redcarpet' gem for Markdown formatting. Install it with `gem install redcarpet`
```

https://github.com/sue445/apple_system_status/actions/runs/20523278914/job/58962051126